### PR TITLE
Replace --tags ~@no_ci with --tags @travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_script:
 script:
   - script/ci/travis/bundle-install.rb
   - script/ci/travis/build-and-stage-app.sh
-  - script/ci/travis/cucumber-ci.rb --tags ~@no_ci --tags ~@scroll
+  - script/ci/travis/cucumber-ci.rb --tags @travis
 
 notifications:
   email:

--- a/CalSmokeApp/config/xtc-profiles.yml
+++ b/CalSmokeApp/config/xtc-profiles.yml
@@ -9,7 +9,6 @@ ipad_only:   --tags ~@iphone --tags ~@iphone_only
 tags:        -p not_xtc -p not_sim -p no_launch
 
 default:     -p tags
-ci:          -p tags --tags ~@no_ci
 
 wip:         -p tags --tags @wip
 flicker:     -p tags --tags @flickering

--- a/CalSmokeApp/features/drag-and-drop.feature
+++ b/CalSmokeApp/features/drag-and-drop.feature
@@ -1,4 +1,3 @@
-@no_ci
 @drag_and_drop
 Feature: Drag and Drop
   In order to test the Calabash pan API

--- a/CalSmokeApp/features/keyboard.feature
+++ b/CalSmokeApp/features/keyboard.feature
@@ -1,9 +1,8 @@
 @travis
-Feature: Interacting with the
+Feature: Typing on the Keyboard
   In order to enter text like a user
   As an app tester
   I want Calabash to provide a Keyboard API
-Feature: say hello to the first view
 
   Scenario: I should be able to type something
     Given I see the first tab

--- a/CalSmokeApp/features/keyboard.feature
+++ b/CalSmokeApp/features/keyboard.feature
@@ -1,7 +1,9 @@
+@travis
 Feature: Interacting with the
   In order to enter text like a user
   As an app tester
   I want Calabash to provide a Keyboard API
+Feature: say hello to the first view
 
   Scenario: I should be able to type something
     Given I see the first tab

--- a/CalSmokeApp/features/keychain.feature
+++ b/CalSmokeApp/features/keychain.feature
@@ -1,4 +1,3 @@
-@no_ci
 @resetting
 @ideviceinstaller
 @keychain

--- a/CalSmokeApp/features/screenshots.feature
+++ b/CalSmokeApp/features/screenshots.feature
@@ -1,4 +1,3 @@
-@no_ci
 @screenshots
 Feature:  Screenshots
   In order to gain insights into my app

--- a/CalSmokeApp/features/scroll.feature
+++ b/CalSmokeApp/features/scroll.feature
@@ -1,5 +1,4 @@
 @scroll
-@no_ci
 Feature: Testing scrolling
 
   Background: I am in the second tab

--- a/CalSmokeApp/features/server_log_level.feature
+++ b/CalSmokeApp/features/server_log_level.feature
@@ -1,4 +1,3 @@
-@no_ci
 @server_log_level
 Feature:  Server Log Level
   In order to gain insights about the server runtime

--- a/CalSmokeApp/features/user_defaults.feature
+++ b/CalSmokeApp/features/user_defaults.feature
@@ -1,4 +1,3 @@
-@no_ci
 @resetting
 @ideviceinstaller
 @user_defaults


### PR DESCRIPTION
### Motivation

The double negative `~@no_ci` convention was starting to get in the way.  It turns out there is only one Feature run on Travis CI.  Marking that feature with @travis makes more sense.