### PR TITLE
Cucumber: add screenshot embed test from calabash-ios

### DIFF
--- a/CalSmokeApp/features/issue_246_screenshot_embed.feature
+++ b/CalSmokeApp/features/issue_246_screenshot_embed.feature
@@ -1,0 +1,17 @@
+@screenshot
+@issue_246
+@wip
+Feature:  Screenshot embed in and out of cucumber world
+
+# undefined method `embed` (NoMethodError) when calling screenshot_and_raise
+# https://github.com/calabash/calabash-ios/issues/246
+
+Scenario: screenshot_and_raise in the context of cucumber
+When I use screenshot_and_raise in the context of cucumber
+Then I should get a runtime error
+
+Scenario: screenshot_and_raise outside the context of cucumber
+When I screenshot_and_raise outside the context of cucumber
+Then I should get a runtime error
+But it should not be a NoMethod error for embed
+

--- a/CalSmokeApp/features/step_definitions/issue_246_screenshot_steps.rb
+++ b/CalSmokeApp/features/step_definitions/issue_246_screenshot_steps.rb
@@ -1,0 +1,30 @@
+When(/^I use screenshot_and_raise in the context of cucumber$/) do
+  begin
+    screenshot_and_raise 'Hey!'
+  rescue StandardError => e
+    @screenshot_and_raise_error = e
+  end
+end
+
+Then(/^I should get a runtime error$/) do
+  if @screenshot_and_raise_error.nil?
+    raise 'Expected the previous step to raise an error'
+  end
+end
+
+When(/^I screenshot_and_raise outside the context of cucumber$/) do
+  begin
+    NotPOM::HomePage.new.my_buggy_method
+  rescue StandardError => e
+    @screenshot_and_raise_error = e
+  end
+end
+
+But(/^it should not be a NoMethod error for embed$/) do
+  error = @screenshot_and_raise_error
+  is_a_no_method_error = error.is_a?(NoMethodError)
+
+  if is_a_no_method_error
+    raise "Expected '#{error}' not to be a NoMethodError"
+  end
+end

--- a/CalSmokeApp/features/step_definitions/models/not-pom/home_page.rb
+++ b/CalSmokeApp/features/step_definitions/models/not-pom/home_page.rb
@@ -1,0 +1,10 @@
+module NotPOM
+  class HomePage
+    include Calabash::Cucumber::Operations
+
+    def my_buggy_method
+      screenshot_and_raise 'Hey!'
+    end
+
+  end
+end


### PR DESCRIPTION
It is too difficult to maintain and run the tests in `calabash-cucumber/test/cucumber`.

