### PR TITLE
Revive screenshot embed tests

### DIFF
--- a/CalSmokeApp/config/cucumber.yml
+++ b/CalSmokeApp/config/cucumber.yml
@@ -2,36 +2,25 @@
 
 require 'run_loop'
 
-date = Time.now.strftime('%Y-%m-%d-%H%M-%S')
-
-FileUtils.mkdir("./screenshots") unless File.exists?("./screenshots")
-FileUtils.mkdir("./reports") unless File.exists?("./reports")
+ss_path = "./screenshots/"
+FileUtils.rm_rf(ss_path)
+FileUtils.mkdir(ss_path)
 
 xamarin_dir = "#{ENV['HOME']}/.xamarin"
-
 devices = {}
-
 device_list = ['neptune', 'venus', 'earp', 'mars', 'saturn', 'pegasi', 'hat', 'erik', 'denis', 'uranus']
-
 device_list.each do |device|
   dir = "#{xamarin_dir}/devices/#{device}"
   ip = IO.read("#{dir}/ip") if File.exists?("#{dir}/ip")
   udid = IO.read("#{dir}/udid") if File.exists?("#{dir}/udid")
-  report = "./reports/#{device}/#{date}-#{device}.html"
-  ss_path = "./reports/#{device}/screenshots/"
   ht = {:dir => dir,
         :ip => ip,
-        :udid => udid,
-        :report => report,
-        :ss_path => ss_path}
+        :udid => udid}
   devices[device.to_sym] = ht
 
   FileUtils.mkdir("./reports/#{device}") unless File.exists?("./reports/#{device}")
   FileUtils.mkdir("./reports/#{device}/screenshots") unless File.exists?("./reports/#{device}/screenshots")
 end
-
-default_report = "./reports/calabash-#{date}.html"
-ss_path = "./screenshots/"
 
 if ENV["USER"] == "jenkins"
   formatter = "pretty"
@@ -47,30 +36,13 @@ app = ENV["APP"] || ENV["APP_BUNDLE_PATH"] || default_app
 %>
 
 verbose: CALABASH_FULL_CONSOLE_OUTPUT=1 DEBUG=1
-common: -f <%= formatter %>
-
-ss_path: SCREENSHOT_PATH=<%= ss_path %>
-
-html_report:  -f 'Calabash::Formatters::Html' -o <%= default_report %>
-neptune_html: -f 'Calabash::Formatters::Html' -o <%= devices[:neptune][:report] %>
-venus_html:   -f 'Calabash::Formatters::Html' -o <%= devices[:venus][:report] %>
-earp_html:    -f 'Calabash::Formatters::Html' -o <%= devices[:earp][:report] %>
-mars_html:    -f 'Calabash::Formatters::Html' -o <%= devices[:mars][:report] %>
-saturn_html:  -f 'Calabash::Formatters::Html' -o <%= devices[:saturn][:report] %>
-pegasi_html:  -f 'Calabash::Formatters::Html' -o <%= devices[:pegasi][:report] %>
-
-neptune_ss: SCREENSHOT_PATH=<%= devices[:neptune][:ss_path] %>
-venus_ss:   SCREENSHOT_PATH=<%= devices[:venus][:ss_path] %>
-earp_ss:    SCREENSHOT_PATH=<%= devices[:earp][:ss_path] %>
-mars_ss:    SCREENSHOT_PATH=<%= devices[:mars][:ss_path] %>
-saturn_ss:  SCREENSHOT_PATH=<%= devices[:saturn][:ss_path] %>
-pegasi_ss:  SCREENSHOT_PATH=<%= devices[:pegasi][:ss_path] %>
+common: -f <%= formatter %> SCREENSHOT_PATH=<%= ss_path %>
 
 reset_btw:    RESET_BETWEEN_SCENARIOS=1
 
 app:          APP=<%= app %>
 
-simulator:     -p app -p common -p ss_path -p html_report --tags ~@device_only --tags ~@device NO_STOP=<%= keep_sim_open_after %>
+simulator:     -p app -p common --tags ~@device_only --tags ~@device NO_STOP=<%= keep_sim_open_after %>
 default:       -p simulator
 
 # required only for devices
@@ -78,25 +50,22 @@ bundle_id:    BUNDLE_ID=sh.calaba.CalSmoke-cal
 
 device_common:  -p common -p bundle_id --tags ~@simulator --tags ~@simulator_only
 
-neptune_common: DEVICE_TARGET=<%= devices[:neptune][:udid] %> DEVICE_ENDPOINT=<%= devices[:neptune][:ip] %> -p device_common  -p neptune_html -p neptune_ss
-
-# cannot test email views without launching on iOS 6
+neptune_common: DEVICE_TARGET=<%= devices[:neptune][:udid] %> DEVICE_ENDPOINT=<%= devices[:neptune][:ip] %> -p device_common
 neptune:           -p neptune_common
-neptune_no_launch: -p neptune_common -p no_launch --tags ~@email
 
 venus_common:   DEVICE_TARGET=<%= devices[:venus][:udid] %>   DEVICE_ENDPOINT=<%= devices[:venus][:ip] %> -p device_common
 venus:          -p venus_common
 
-earp_common:   DEVICE_TARGET=<%= devices[:earp][:udid] %> DEVICE_ENDPOINT=<%= devices[:earp][:ip] %> -p device_common  -p earp_html -p earp_ss
+earp_common:   DEVICE_TARGET=<%= devices[:earp][:udid] %> DEVICE_ENDPOINT=<%= devices[:earp][:ip] %> -p device_common
 earp:          -p earp_common
 
-mars_common:   DEVICE_TARGET=<%= devices[:mars][:udid] %> DEVICE_ENDPOINT=<%= devices[:mars][:ip] %> -p device_common  -p mars_html -p mars_ss
+mars_common:   DEVICE_TARGET=<%= devices[:mars][:udid] %> DEVICE_ENDPOINT=<%= devices[:mars][:ip] %> -p device_common
 mars:          -p mars_common
 
-saturn_common:   DEVICE_TARGET=<%= devices[:saturn][:udid] %> DEVICE_ENDPOINT=<%= devices[:saturn][:ip] %> -p device_common  -p saturn_html -p saturn_ss
+saturn_common:   DEVICE_TARGET=<%= devices[:saturn][:udid] %> DEVICE_ENDPOINT=<%= devices[:saturn][:ip] %> -p device_common
 saturn:          -p saturn_common
 
-pegasi_common:   DEVICE_TARGET=<%= devices[:pegasi][:udid] %> DEVICE_ENDPOINT=<%= devices[:pegasi][:ip] %> -p device_common  -p pegasi_html -p pegasi_ss
+pegasi_common:   DEVICE_TARGET=<%= devices[:pegasi][:udid] %> DEVICE_ENDPOINT=<%= devices[:pegasi][:ip] %> -p device_common
 pegasi:          -p pegasi_common
 
 hat:   DEVICE_TARGET=<%= devices[:hat][:udid] %> DEVICE_ENDPOINT=<%= devices[:hat][:ip] %> -p device_common

--- a/CalSmokeApp/features/issue_246_screenshot_embed.feature
+++ b/CalSmokeApp/features/issue_246_screenshot_embed.feature
@@ -5,12 +5,17 @@ Feature:  Screenshot embed in and out of cucumber world
 # undefined method `embed` (NoMethodError) when calling screenshot_and_raise
 # https://github.com/calabash/calabash-ios/issues/246
 
-Scenario: screenshot_and_raise in the context of cucumber
+Scenario: screenshots outside of a page
 When I use screenshot_and_raise in the context of cucumber
 Then I should get a runtime error
 
-Scenario: screenshot_and_raise outside the context of cucumber
-When I screenshot_and_raise outside the context of cucumber
+Scenario: screenshots in a page that does not extend IBase
+When I screenshot_and_raise in a page that does not inherit from IBase
+Then I should get a runtime error
+But it should not be a NoMethod error for embed
+
+Scenario: screenshots in a page that does extend IBase
+When I screenshot_and_raise in a page that does inherit from IBase
 Then I should get a runtime error
 But it should not be a NoMethod error for embed
 

--- a/CalSmokeApp/features/pages/not_pom.rb
+++ b/CalSmokeApp/features/pages/not_pom.rb
@@ -1,0 +1,11 @@
+module NotPOM
+  class HomePage
+    include Calabash::Cucumber::Operations
+
+    def my_buggy_method
+      screenshot_and_raise 'Hey!'
+    end
+
+  end
+end
+

--- a/CalSmokeApp/features/pages/pom.rb
+++ b/CalSmokeApp/features/pages/pom.rb
@@ -1,0 +1,12 @@
+module POM
+  require "calabash-cucumber/ibase"
+
+  class HomePage < Calabash::IBase
+
+    def my_buggy_method
+      screenshot_and_raise 'Hey!'
+    end
+
+  end
+end
+

--- a/CalSmokeApp/features/step_definitions/issue_246_screenshot_steps.rb
+++ b/CalSmokeApp/features/step_definitions/issue_246_screenshot_steps.rb
@@ -1,8 +1,69 @@
+module CalSmokeApp
+  module ScreenshotEmbed
+
+    def screenshot_count
+      screenshot_dir = ENV["SCREENSHOT_PATH"]
+      if !screenshot_dir
+        screenshot_dir = "./screenshots"
+      end
+
+      unless File.exist?(screenshot_dir)
+        FileUtils.mkdir_p(screenshot_dir)
+      end
+
+      Dir.glob("#{screenshot_dir}/*.png").count
+    end
+
+    def log_screenshot_context(kontext, e)
+      $stdout.puts "  #{kontext} #{e.class} #{e.message}"
+      $stdout.flush
+    end
+
+    def expect_screenshot_count(expected)
+      if Calabash::Cucumber::Environment.xtc?
+        # Skip this test on the XTC.
+      else
+        expect(screenshot_count).to be == expected
+      end
+    end
+  end
+end
+
+World(CalSmokeApp::ScreenshotEmbed)
+
 When(/^I use screenshot_and_raise in the context of cucumber$/) do
+  last_count = screenshot_count
+
   begin
     screenshot_and_raise 'Hey!'
-  rescue StandardError => e
+  rescue => e
     @screenshot_and_raise_error = e
+    log_screenshot_context("Cucumber", e)
+    expect_screenshot_count(last_count + 1)
+  end
+end
+
+When(/I screenshot_and_raise in a page that does not inherit from IBase$/) do
+  last_count = screenshot_count
+
+  begin
+    NotPOM::HomePage.new.my_buggy_method
+  rescue => e
+    log_screenshot_context("NotPOM", e)
+    @screenshot_and_raise_error = e
+    expect_screenshot_count(last_count + 1)
+  end
+end
+
+When(/I screenshot_and_raise in a page that does inherit from IBase$/) do
+  last_count = screenshot_count
+
+  begin
+    POM::HomePage.new(self).my_buggy_method
+  rescue => e
+    log_screenshot_context("POM", e)
+    @screenshot_and_raise_error = e
+    expect_screenshot_count(last_count + 1)
   end
 end
 
@@ -10,21 +71,12 @@ Then(/^I should get a runtime error$/) do
   if @screenshot_and_raise_error.nil?
     raise 'Expected the previous step to raise an error'
   end
-end
 
-When(/^I screenshot_and_raise outside the context of cucumber$/) do
-  begin
-    NotPOM::HomePage.new.my_buggy_method
-  rescue StandardError => e
-    @screenshot_and_raise_error = e
-  end
+  expect(@screenshot_and_raise_error).to be_a_kind_of(RuntimeError)
 end
 
 But(/^it should not be a NoMethod error for embed$/) do
-  error = @screenshot_and_raise_error
-  is_a_no_method_error = error.is_a?(NoMethodError)
-
-  if is_a_no_method_error
-    raise "Expected '#{error}' not to be a NoMethodError"
-  end
+  expect(@screenshot_and_raise_error.message[/embed/, 0]).to be_falsey
+  expect(@screenshot_and_raise_error).not_to be_a_kind_of(NoMethodError)
 end
+


### PR DESCRIPTION
### Motivation

Somewhere along the way we lost the Cucumbers for testing screenshots.

Tests fix for **0.19.0: undefined method `embed` in Calabash::Cucumber.map** [#1083](https://github.com/calabash/calabash-ios/issues/1083)
