### PR TITLE
Update ruby test env and respond to Jenkins reinstall 

### DIFF
--- a/CalSmokeApp/Gemfile
+++ b/CalSmokeApp/Gemfile
@@ -1,11 +1,12 @@
 source 'https://rubygems.org'
 
 gem 'calabash-cucumber', :github => "calabash/calabash-ios", :branch => "develop"
+gem "cucumber", "2.99.0"
 gem "run_loop", :github => "calabash/run_loop", :branch => "develop"
+gem "json", "1.8.6"
 
 # workflow and build tools
 gem 'retriable', '~> 2.0'
-gem "cucumber", "~> 2.0"
 gem 'rake', '~> 10.3'
 gem 'bundler', '~> 1.6'
 gem 'xcpretty', '~> 0.1'

--- a/CalSmokeApp/bin/make/ipa-cal.sh
+++ b/CalSmokeApp/bin/make/ipa-cal.sh
@@ -133,7 +133,8 @@ fi
 cat >"${XTC_DIR}/Gemfile" <<EOF
 source "https://rubygems.org"
 
-gem "calabash-cucumber"
+gem "calabash-cucumber", "2.99.0"
+gem "json", "1.8.6"
 EOF
 
 cat "config/xtc-other-gems.rb" >> "${XTC_DIR}/Gemfile"

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,6 @@
 source "https://rubygems.org"
 
 gem "run_loop", github: "calabash/run_loop", branch: "develop"
+gem "json", "1.8.6"
 gem "luffa", github: "calabash/luffa", branch: "develop"
 gem "bundler"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,7 +13,6 @@ pipeline {
   }
   options {
     disableConcurrentBuilds()
-    timestamps()
     buildDiscarder(logRotator(numToKeepStr: '10'))
     timeout(time: 60, unit: 'MINUTES')
   }


### PR DESCRIPTION
### Motivation

Jenkins has been reinstalled and the timestamper plug-in removed.

Calabash iOS will soon be agnostic re: the cucumber version.

run_loop will soon be agnostic re: the json version