### PR TITLE
Add Xcode 11.1 and 11.2 to the test matrix

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,6 +33,12 @@ jobs:
       Mojave-Xcode-11.0:
         IMAGE_POOL: 'macOS-10.14'
         XCODE_VERSION: '11'
+      Mojave-Xcode-11.1:
+        IMAGE_POOL: 'macOS-10.14'
+        XCODE_VERSION: '11.1'
+      Mojave-Xcode-11.2:
+        IMAGE_POOL: 'macOS-10.14'
+        XCODE_VERSION: '11.2'
   pool:
     vmImage: $(IMAGE_POOL)
 


### PR DESCRIPTION
In this PR we added Xcode 11.1 and Xcode 11.2 to the `ios-smoke-test-app` test matrix in ADO pipeline